### PR TITLE
Update to easy-table ^1.1.0

### DIFF
--- a/lib/mtrace.js
+++ b/lib/mtrace.js
@@ -10,8 +10,8 @@ Table.prototype.totals = function(keys, label) {
     label = label || 'Totals';
     var totals = {};
     var ii, jj, key;
-    for (ii in this.lines) {
-        var line = this.lines[ii];
+    for (ii in this.rows) {
+        var line = this.rows[ii];
         for (jj in keys) {
             key = keys[jj];
             var val = line[key];
@@ -35,17 +35,17 @@ Table.prototype.totals = function(keys, label) {
         first = false;
     }
     // save totals cells
-    var totalLine = this.line;
-    this.line = {};
+    var totalLine = this.row;
+    this.row = {__printers : {}};
     // build divider
     for (key in this.columns) {
         var col = this.columns[key];
         this.cell(key, (new Array(col.length+1)).join('-'));
     }
     // but insert it manually before our totals
-    this.lines.push(this.line);
-    this.lines.push(totalLine);
-    this.line = {};
+    this.rows.push(this.row);
+    this.rows.push(totalLine);
+    this.row = {__printers : {}};
 };
 
 var _bytes_unit_spec = [
@@ -200,7 +200,7 @@ function finish() {
     for (var key in total) {
       total[key] += site_data[key] || 0;
     }
-    t.newLine();
+    t.newRow();
   }
   t.sort(['Size', 'Count', 'Traffic']);
   t.totals(['Size', 'Count', 'Traffic']);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "easy-table": "0.0.3",
+    "easy-table": "^1.1.0",
     "nan": "^2.1.0"
   },
   "engines": {


### PR DESCRIPTION
This fixes a couple of weirdnesses for me:
1. The size was always rendered without unit
2. The module was shortened on the wrong side